### PR TITLE
Refactor: clouseau start

### DIFF
--- a/clouseau/Dockerfile
+++ b/clouseau/Dockerfile
@@ -8,7 +8,7 @@ RUN curl -fsSL "http://archive.apache.org/dist/maven/maven-3/$MAVEN_VERSION/bina
 # -> used artifacts: /usr/share/maven
 
 # --- Stage2: Install Clouseau
-FROM erlang:18-slim as ntr-clouseau
+FROM erlang:18-slim as ntr-clouseau-build
 ENV MAVEN_HOME /usr/share/maven
 ENV CLOUSEAU_PATH /opt/clouseau
 ENV INDEX_DIR /index
@@ -52,12 +52,40 @@ RUN git clone -b ntr_master https://github.com/neutrinity/clouseau . \
 # TODO tests need to get unskipped
 RUN mvn verify -Dmaven.test.skip=true
 
+# --- Stage3: Finalize Clouseau
+FROM erlang:18-slim as ntr-clouseau
+ENV CLOUSEAU_PATH /opt/clouseau
+ENV INDEX_DIR /index
+
+RUN apt-get -qq update -y \
+  && DEBIAN_FRONTEND=noninteractive apt-get -qq install -y apt-utils \
+  && DEBIAN_FRONTEND=noninteractive apt-get -qq install -y --no-install-recommends \
+  libnspr4 libnspr4-0d \
+  openssl \
+  curl \
+  ca-certificates \
+  unzip \
+  openjdk-7-jdk \
+  && rm -rf /var/lib/apt/lists/*
+
+# this is a hack to clean everything up
+RUN mkdir -p "${CLOUSEAU_PATH}/lib" \
+  && groupadd -r clouseau && useradd -d "$CLOUSEAU_PATH" -g clouseau clouseau
+
+WORKDIR $CLOUSEAU_PATH
+
+COPY --from=ntr-clouseau-build "${CLOUSEAU_PATH}/target/clouseau-2.10.0-SNAPSHOT.zip" .
+RUN unzip -j "${CLOUSEAU_PATH}/clouseau-2.10.0-SNAPSHOT.zip" -d "${CLOUSEAU_PATH}/lib"
+
 COPY ./docker-entrypoint.sh $CLOUSEAU_PATH
 
 # Setup directories and permissions
-RUN touch clouseau.ini \
+RUN mkdir -p "${CLOUSEAU_PATH}/etc" \
+  && touch "${CLOUSEAU_PATH}/etc/clouseau.ini" \
   && chmod +x docker-entrypoint.sh \
   && chown -R clouseau:clouseau "$CLOUSEAU_PATH"
+
+COPY ./clouseau/log4j.properties "${CLOUSEAU_PATH}/etc"
 
 RUN mkdir -p "$INDEX_DIR"
 VOLUME ["$INDEX_DIR"]

--- a/clouseau/log4j.properties
+++ b/clouseau/log4j.properties
@@ -1,0 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+log4j.rootLogger=INFO, stdout
+
+log4j.appender.stdout=org.apache.log4j.ConsoleAppender
+log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
+log4j.appender.stdout.layout.ConversionPattern=[%d] %p %m (%c)%n

--- a/docker-compose-hub.yaml
+++ b/docker-compose-hub.yaml
@@ -21,7 +21,7 @@ services:
       - ERLANG_COOKIE=cookie_monster
       - COUCHDB_USER=jan
       - COUCHDB_PASSWORD=password
-      - CLOUSEAU_NAME=clouseau@clouseau.local
+      - CLOUSEAU_NAME=clouseau.local
     volumes:
       - './data/couchdb/:/opt/couchdb/data/'
   clouseau.local:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -35,7 +35,7 @@ services:
     environment:
       - INDEX_DIR=/index
       - ERLANG_COOKIE=cookie_monster
-      - NODE_NAME=clouseau@clouseau.local
+      - NODE_NAME=clouseau.local
     volumes:
       - './data/clouseau/:/index'
     depends_on:

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -3,15 +3,18 @@ set -e
 
 if [ "$1" = 'clouseau' ]; then
     # setup configuration
-    echo '[clouseau]' > clouseau.ini
-    echo "name=${NODE_NAME}" >> clouseau.ini
-    echo "cookie=${ERLANG_COOKIE}" >> clouseau.ini
-    echo "dir=${INDEX_DIR}" >> clouseau.ini
+    echo '[clouseau]' > "${CLOUSEAU_PATH}/etc/clouseau.ini"
+    echo "name=clouseau@${NODE_NAME}" >> "${CLOUSEAU_PATH}/etc/clouseau.ini"
+    echo "cookie=${ERLANG_COOKIE}" >> "${CLOUSEAU_PATH}/etc/clouseau.ini"
+    echo "dir=${INDEX_DIR}" >> "${CLOUSEAU_PATH}/etc/clouseau.ini"
 
     # explicitely start local epmd since for scalang/clouseau there's no automatic launch mechanism like there is for erlang
     epmd -daemon
 
-    mvn scala:run
+    java -Dlog4j.configuration=file:$CLOUSEAU_PATH/etc/log4j.properties \
+    -cp $CLOUSEAU_PATH/etc:$CLOUSEAU_PATH/lib/* \
+    com.cloudant.clouseau.Main \
+    "${CLOUSEAU_PATH}/etc/clouseau.ini"
 fi
 
 if [ "$1" = 'couchdb' ]; then


### PR DESCRIPTION
- removes maven as a dependency to run clouseau and use the compiled artefact
 - clean up log output from clouseau (via proper conf)
 - use multi-stage to further trim the final image (1.1 GB to 550 MB)